### PR TITLE
Hashes in certificate table changed to lowercase

### DIFF
--- a/tools/fileinfo/bugs/certificate-loading-crash/test.py
+++ b/tools/fileinfo/bugs/certificate-loading-crash/test.py
@@ -10,5 +10,5 @@ class Test(Test):
     def test_certificates_are_present(self):
         assert self.fileinfo.succeeded
         self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "2")
-        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "AA03C799E7AFAC2858B79ED9710A63191032CC4099CEC75653064B8FACBD09A1")
-        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "A2BDF61928644D5A0F5CCC93C9B339E600AD1AD05E4682D86C1477CE39997CFF")
+        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "aa03c799e7afac2858b79ed9710a63191032cc4099cec75653064b8facbd09a1")
+        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "a2bdf61928644d5a0f5ccc93c9b339e600ad1ad05e4682d86c1477ce39997cff")

--- a/tools/fileinfo/bugs/certificate-segfault/test.py
+++ b/tools/fileinfo/bugs/certificate-segfault/test.py
@@ -11,8 +11,8 @@ class Test1(Test):
         assert self.fileinfo.succeeded
         assert 'signerCertificateIndex' not in self.fileinfo.output['certificateTable']
         self.assertEqual(self.fileinfo.output['certificateTable']['numberOfCertificates'], '2')
-        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][0]['sha256'], '8815DFF787F21FA8106760CB89C5B4493F4BD45E2CE801D2A4FE1F61DEE0C039')
-        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][1]['sha256'], '1C1983300C10FB262C0B2304B7BE15AABA10AE356EBBBB177583DC44774EB080')
+        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][0]['sha256'], '8815dff787f21fa8106760cb89c5b4493f4bd45e2ce801d2a4fe1f61dee0c039')
+        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][1]['sha256'], '1c1983300c10fb262c0b2304b7be15aaba10ae356ebbbb177583dc44774eb080')
 
 
 class Test2(Test):
@@ -26,7 +26,7 @@ class Test2(Test):
         assert self.fileinfo.succeeded
         assert 'signerCertificateIndex' not in self.fileinfo.output['certificateTable']
         self.assertEqual(self.fileinfo.output['certificateTable']['numberOfCertificates'], '1')
-        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][0]['sha256'], 'CED5AB020125966499A067ABFB138434281BC5B00C90D5D74D31529FF5169BF2')
+        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][0]['sha256'], 'ced5ab020125966499a067abfb138434281bc5b00c90d5d74d31529ff5169bf2')
 
 
 # https://github.com/avast-tl/retdec/issues/255
@@ -42,7 +42,7 @@ class Test3(Test):
 
     def test_certificate_table_present(self):
         assert self.fileinfo.succeeded
-        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][0]['sha256'], 'A2219C3E44EE3748EAE12E5AA6C961AF47C185E25A8E59AFFD8FCAED641286CD')
+        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][0]['sha256'], 'a2219c3e44ee3748eae12e5aa6c961af47c185e25a8e59affd8fcaed641286cd')
 
 
 # https://github.com/avast-tl/retdec/issues/250
@@ -55,4 +55,4 @@ class Test4(Test):
 
     def test_certificate_table_present(self):
         assert self.fileinfo.succeeded
-        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][0]['sha256'], 'F0A14C45793C834FA6B10891813FD27487315E98BF5423D30DCAA44B4B28CD04')
+        self.assertEqual(self.fileinfo.output['certificateTable']['certificates'][0]['sha256'], 'f0a14c45793c834fa6b10891813fd27487315e98bf5423d30dcaa44b4b28cd04')

--- a/tools/fileinfo/features/certificates-info/test.py
+++ b/tools/fileinfo/features/certificates-info/test.py
@@ -10,11 +10,11 @@ class Test1(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "5")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "8FB47562286677514075BC38D1CFD2B73481D93CB3F9C23F9AC3E6414EF34A6F")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "582DC1D97A790EF04FE2567B1EC88C26B03BF6E99937CAE6A0B50397AD20BBF8")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "8420DFBE376F414BF4C0A81E6936D24CCC03F304835B86C7A39142FCA723A689")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881C9B74D31F28DC580B0F2B9D2B14A97CE31CBEC2A05AEB377DCDDCC2B0")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625FEE1A80D7B897A9712249C2F55FF391D6661DBD8B87F9BE6F252D88CED95")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "8fb47562286677514075bc38d1cfd2b73481d93cb3f9c23f9ac3e6414ef34a6f")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "582dc1d97a790ef04fe2567b1ec88c26b03bf6e99937cae6a0b50397ad20bbf8")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "8420dfbe376f414bf4c0a81e6936d24ccc03f304835b86c7a39142fca723a689")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881c9b74d31f28dc580b0f2b9d2b14a97ce31cbec2a05aeb377dcddcc2b0")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625fee1a80d7b897a9712249c2f55ff391d6661dbd8b87f9be6f252d88ced95")
 
 class Test2(Test):
 	settings=TestSettings(
@@ -26,11 +26,11 @@ class Test2(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "5")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "3B0ABE047D7E84F3BBD12B5E399BED55E4D7E9FCC3F629B8953A8C060EF6D746")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "0CFC19DB681B014BFE3F23CB3A78B67208B4E3D8D7B6A7B1807F7CD6ECB2A54E")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "8420DFBE376F414BF4C0A81E6936D24CCC03F304835B86C7A39142FCA723A689")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881C9B74D31F28DC580B0F2B9D2B14A97CE31CBEC2A05AEB377DCDDCC2B0")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625FEE1A80D7B897A9712249C2F55FF391D6661DBD8B87F9BE6F252D88CED95")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "3b0abe047d7e84f3bbd12b5e399bed55e4d7e9fcc3f629b8953a8c060ef6d746")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "0cfc19db681b014bfe3f23cb3a78b67208b4e3d8d7b6a7b1807f7cd6ecb2a54e")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "8420dfbe376f414bf4c0a81e6936d24ccc03f304835b86c7a39142fca723a689")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881c9b74d31f28dc580b0f2b9d2b14a97ce31cbec2a05aeb377dcddcc2b0")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625fee1a80d7b897a9712249c2f55ff391d6661dbd8b87f9be6f252d88ced95")
 
 class Test3(Test):
 	settings=TestSettings(
@@ -42,11 +42,11 @@ class Test3(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "5")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "FCB433D6D1AFBEC9E8F5447C2C0FA4AE7553986D5C2703BE82524BE608F35F61")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "53793CFC1B2B5096CC4EDBEC527ABC5CBC20470C788162D9E54C370D51625F4A")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "C766A9BEF2D4071C863A31AA4920E813B2D198608CB7B7CFE21143B836DF09EA")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881C9B74D31F28DC580B0F2B9D2B14A97CE31CBEC2A05AEB377DCDDCC2B0")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625FEE1A80D7B897A9712249C2F55FF391D6661DBD8B87F9BE6F252D88CED95")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "fcb433d6d1afbec9e8f5447c2c0fa4ae7553986d5c2703be82524be608f35f61")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "53793cfc1b2b5096cc4edbec527abc5cbc20470c788162d9e54c370d51625f4a")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "c766a9bef2d4071c863a31aa4920e813b2d198608cb7b7cfe21143b836df09ea")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881c9b74d31f28dc580b0f2b9d2b14a97ce31cbec2a05aeb377dcddcc2b0")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625fee1a80d7b897a9712249c2f55ff391d6661dbd8b87f9be6f252d88ced95")
 
 class Test4(Test):
 	settings=TestSettings(
@@ -58,11 +58,11 @@ class Test4(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "5")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "E2DBA399BE32992B74DF8A86CFD9886C2304CCC19DA8A9BE2B87809DA006379E")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "973A41276FFD01E027A2AAD49E34C37846D3E976FF6A620B6712E33832041AA6")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "3A2FBE92891E57FE05D57087F48E730F17E5A5F53EF403D618E5B74D7A7E6ECB")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881C9B74D31F28DC580B0F2B9D2B14A97CE31CBEC2A05AEB377DCDDCC2B0")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625FEE1A80D7B897A9712249C2F55FF391D6661DBD8B87F9BE6F252D88CED95")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "e2dba399be32992b74df8a86cfd9886c2304ccc19da8a9be2b87809da006379e")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "973a41276ffd01e027a2aad49e34c37846d3e976ff6a620b6712e33832041aa6")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "3a2fbe92891e57fe05d57087f48e730f17e5a5f53ef403d618e5b74d7a7e6ecb")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881c9b74d31f28dc580b0f2b9d2b14a97ce31cbec2a05aeb377dcddcc2b0")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625fee1a80d7b897a9712249c2f55ff391d6661dbd8b87f9be6f252d88ced95")
 
 class Test5(Test):
 	settings=TestSettings(
@@ -74,11 +74,11 @@ class Test5(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "5")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "1A73BF16814D061CF5930634FBBD8A55E53DF2A556469C48FDF2623DFEEEE8A8")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "51044706BD237B91B89B781337E6D62656C69F0FCFFBE8E43741367948127862")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "3E9099B5015E8F486C00BCEA9D111EE721FABA355A89BCF1DF69561E3DC6325C")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881C9B74D31F28DC580B0F2B9D2B14A97CE31CBEC2A05AEB377DCDDCC2B0")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625FEE1A80D7B897A9712249C2F55FF391D6661DBD8B87F9BE6F252D88CED95")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "1a73bf16814d061cf5930634fbbd8a55e53df2a556469c48fdf2623dfeeee8a8")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "51044706bd237b91b89b781337e6d62656c69f0fcffbe8e43741367948127862")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "3e9099b5015e8f486c00bcea9d111ee721faba355a89bcf1df69561e3dc6325c")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881c9b74d31f28dc580b0f2b9d2b14a97ce31cbec2a05aeb377dcddcc2b0")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625fee1a80d7b897a9712249c2f55ff391d6661dbd8b87f9be6f252d88ced95")
 
 class Test6(Test):
 	settings=TestSettings(
@@ -90,11 +90,11 @@ class Test6(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "5")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "FCB433D6D1AFBEC9E8F5447C2C0FA4AE7553986D5C2703BE82524BE608F35F61")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "53793CFC1B2B5096CC4EDBEC527ABC5CBC20470C788162D9E54C370D51625F4A")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "C766A9BEF2D4071C863A31AA4920E813B2D198608CB7B7CFE21143B836DF09EA")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881C9B74D31F28DC580B0F2B9D2B14A97CE31CBEC2A05AEB377DCDDCC2B0")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625FEE1A80D7B897A9712249C2F55FF391D6661DBD8B87F9BE6F252D88CED95")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "fcb433d6d1afbec9e8f5447c2c0fa4ae7553986d5c2703be82524be608f35f61")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "53793cfc1b2b5096cc4edbec527abc5cbc20470c788162d9e54c370d51625f4a")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "c766a9bef2d4071c863a31aa4920e813b2d198608cb7b7cfe21143b836df09ea")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881c9b74d31f28dc580b0f2b9d2b14a97ce31cbec2a05aeb377dcddcc2b0")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625fee1a80d7b897a9712249c2f55ff391d6661dbd8b87f9be6f252d88ced95")
 
 class Test7(Test):
 	settings=TestSettings(
@@ -106,10 +106,10 @@ class Test7(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "4")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "67C529AD57B2AEDD4D248993324270C7064D4F6BDAAF70044D772D05C56001A4")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "9CBF22FAE0DD53A7395556CE6154AA14A0D03360AA8C51CFEA05D1FD8819E043")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "6413CBCF5C6AB255868033D4E701B579B2509A47C3C18B3199C140D20209C19D")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "4F987BBE4E0D1DCF48FCEFC9239AC6E62EE9DF38CAC2D32993B8533CD95C2E49")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "67c529ad57b2aedd4d248993324270c7064d4f6bdaaf70044d772d05c56001a4")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "9cbf22fae0dd53a7395556ce6154aa14a0d03360aa8c51cfea05d1fd8819e043")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "6413cbcf5c6ab255868033d4e701b579b2509a47c3c18b3199c140d20209c19d")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "4f987bbe4e0d1dcf48fcefc9239ac6e62ee9df38cac2d32993b8533cd95c2e49")
 
 class Test8(Test):
 	settings=TestSettings(
@@ -121,10 +121,10 @@ class Test8(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "4")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "BB70F99803DB3F20919852D5AF93BCAD68F4F9109C8014676EE2CDD6FFDD1A8E")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "5E6D2F88F617DC8B809AEE712445A41B3CDE26AF874A221A9DC98EA1DC68E3D5")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "4F32D5DC00F715250ABCC486511E37F501A899DEB3BF7EA8ADBBD3AEF1C412DA")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "12F0A1DDF83D265B205B4F3BCA43B3FA89A748E9834EC24004774FD2FDE34073")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "bb70f99803db3f20919852d5af93bcad68f4f9109c8014676ee2cdd6ffdd1a8e")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "5e6d2f88f617dc8b809aee712445a41b3cde26af874a221a9dc98ea1dc68e3d5")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "4f32d5dc00f715250abcc486511e37f501a899deb3bf7ea8adbbd3aef1c412da")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "12f0a1ddf83d265b205b4f3bca43b3fa89a748e9834ec24004774fd2fde34073")
 
 class Test9(Test):
 	settings=TestSettings(
@@ -136,11 +136,11 @@ class Test9(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "5")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "1A73BF16814D061CF5930634FBBD8A55E53DF2A556469C48FDF2623DFEEEE8A8")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "51044706BD237B91B89B781337E6D62656C69F0FCFFBE8E43741367948127862")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "3E9099B5015E8F486C00BCEA9D111EE721FABA355A89BCF1DF69561E3DC6325C")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881C9B74D31F28DC580B0F2B9D2B14A97CE31CBEC2A05AEB377DCDDCC2B0")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625FEE1A80D7B897A9712249C2F55FF391D6661DBD8B87F9BE6F252D88CED95")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "1a73bf16814d061cf5930634fbbd8a55e53df2a556469c48fdf2623dfeeee8a8")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "51044706bd237b91b89b781337e6d62656c69f0fcffbe8e43741367948127862")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "3e9099b5015e8f486c00bcea9d111ee721faba355a89bcf1df69561e3dc6325c")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0374881c9b74d31f28dc580b0f2b9d2b14a97ce31cbec2a05aeb377dcddcc2b0")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][4]["sha256"], "0625fee1a80d7b897a9712249c2f55ff391d6661dbd8b87f9be6f252d88ced95")
 
 class Test10(Test):
 	settings=TestSettings(
@@ -152,10 +152,10 @@ class Test10(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "4")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "67C529AD57B2AEDD4D248993324270C7064D4F6BDAAF70044D772D05C56001A4")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "9CBF22FAE0DD53A7395556CE6154AA14A0D03360AA8C51CFEA05D1FD8819E043")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "E43F82BC40029F17DBB516613D1E1A96EC2940CE76E0A9CD5F53BA50175A8766")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "4F987BBE4E0D1DCF48FCEFC9239AC6E62EE9DF38CAC2D32993B8533CD95C2E49")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "67c529ad57b2aedd4d248993324270c7064d4f6bdaaf70044d772d05c56001a4")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "9cbf22fae0dd53a7395556ce6154aa14a0d03360aa8c51cfea05d1fd8819e043")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "e43f82bc40029f17dbb516613d1e1a96ec2940ce76e0a9cd5f53ba50175a8766")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "4f987bbe4e0d1dcf48fcefc9239ac6e62ee9df38cac2d32993b8533cd95c2e49")
 
 class TestEscaping(Test):
 	settings=TestSettings(
@@ -167,10 +167,10 @@ class TestEscaping(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "4")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "9D5DC543A16E3B97AA12ABB6A09C9393C1F6778E475D95C81607335D5D19AF8B")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "0D34394100E961CE4318DBA9B8DD38EBC25BB07AEF78FDA3FFF632685549BA0F")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "0374881C9B74D31F28DC580B0F2B9D2B14A97CE31CBEC2A05AEB377DCDDCC2B0")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0625FEE1A80D7B897A9712249C2F55FF391D6661DBD8B87F9BE6F252D88CED95")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "9d5dc543a16e3b97aa12abb6a09c9393c1f6778e475d95c81607335d5d19af8b")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "0d34394100e961ce4318dba9b8dd38ebc25bb07aef78fda3fff632685549ba0f")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "0374881c9b74d31f28dc580b0f2b9d2b14a97ce31cbec2a05aeb377dcddcc2b0")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "0625fee1a80d7b897a9712249c2f55ff391d6661dbd8b87f9be6f252d88ced95")
 		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["attributes"]["subject"]["locality"], R"M\xfcnchen")
 
 class Test11(Test):
@@ -183,6 +183,6 @@ class Test11(Test):
 	def test_certificates(self):
 		assert self.fileinfo.succeeded
 		self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "3")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "D271598ADB52545B0094E806AF9C4702D857B29D43D6896C523EEF7758519153")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "09ED6E991FC3273D8FEA317D339C02041861973549CFA6E1558F411F11211AA3")
-		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "C3846BF24B9E93CA64274C0EC67C1ECC5E024FFCACD2D74019350E81FE546AE4")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "d271598adb52545b0094e806af9c4702d857b29d43d6896c523eef7758519153")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "09ed6e991fc3273d8fea317d339c02041861973549cfa6e1558f411f11211aa3")
+		self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "c3846bf24b9e93ca64274c0ec67c1ecc5e024ffcacd2d74019350e81fe546ae4")

--- a/tools/unpacker/upx/features/certificate-info/test.py
+++ b/tools/unpacker/upx/features/certificate-info/test.py
@@ -11,7 +11,7 @@ class Test(Test):
         assert self.unpacker.succeeded
         assert self.fileinfo.succeeded
         self.assertEqual(self.fileinfo.output["certificateTable"]["numberOfCertificates"], "4")
-        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "F63B42F1E0C3950730D95B3B6B78B8F7C7991097B5F8D81F64B2C83A1DECF5CA")
-        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "8EF8F2565BE30E7CE7BA6302BB18B42A3ACD148A0DDB4779E4C03E862F39589B")
-        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "2CF1EC6AB594113BD538DF6D5C940E3319B424F8756D975888072C6AB558B771")
-        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "2463525300D9E8E0A6F5D79E2B20B9F5182FE40D3FD7C85DDAF48E6C25BEDF5D")
+        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][0]["sha256"], "f63b42f1e0c3950730d95b3b6b78b8f7c7991097b5f8d81f64b2c83a1decf5ca")
+        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][1]["sha256"], "8ef8f2565be30e7ce7ba6302bb18b42a3acd148a0ddb4779e4c03e862f39589b")
+        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][2]["sha256"], "2cf1ec6ab594113bd538df6d5c940e3319b424f8756d975888072c6ab558b771")
+        self.assertEqual(self.fileinfo.output["certificateTable"]["certificates"][3]["sha256"], "2463525300d9e8e0a6f5d79e2b20b9f5182fe40d3fd7c85ddaf48e6c25bedf5d")


### PR DESCRIPTION
Hashes in certificate table changed to lowercase in order to reflect [pull request #543](https://github.com/avast-tl/retdec/pull/543).